### PR TITLE
Fix Issue #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,12 @@ To set up **MergeSentinel** locally:
 {
   "gitlab_token": "<token>",
   "gitlab_url": "https://<gitlab URL>",
+  "webhook_token": "<webhook token>",
   "projects": [
     {
       "project_id": <ID>,
       "approvals": ["<user1>", "<user2>", "<user3>"],
+      "webhook_token": "<webhook token>",
       "min_approv": 2
     }
   ],
@@ -56,10 +58,12 @@ To set up **MergeSentinel** locally:
 
 - **`gitlab_token`**: The personal access token for authenticating API requests to GitLab.
 - **`gitlab_url`**: The base URL of your GitLab instance.
+- **`webhook_token`**: The webhook token used in gitlab webhook calls. If not defined in project level, this one will be used.
 - **`projects`**: An array of project-specific configurations:
     - **`project_id`**: The ID of the GitLab project.
     - **`approvals`**: A list of users required to approve the merge request.
     - **`min_approv`**: The minimum number of approvals required to allow the merge request to proceed.
+    - **`webhook_token`**: The webhook token used in gitlab webhook calls.
 - **`psql_conn_url`**: The PostgreSQL connection URL for accessing the GitLab database, including user credentials, the fully qualified domain name (FQDN) of the GitLab PostgreSQL server, and the name of the database (**`gitlabhq_production`**).
 
 ## Usage
@@ -74,6 +78,21 @@ Example configuration:
 4. Save the webhook.
 
 **MergeSentinel** will now monitor merge requests and enforce your rules.
+
+## postgreSQL configuration
+
+MergeSentinel will call gitlab postgreSQL server to update merge request table. It will be a SELECT and an UPDATE query, like:
+```bash
+SELECT * FROM merge_requests WHERE iid = 1 AND target_project_id = 1;
+```
+```bash
+UPDATE merge_requests SET merge_status = 'cannot_be_merged', merge_error = ''Requires at least 2 approvals from [user1 user7]. WHERE iid = 1 AND target_project_id = 1;
+```
+You can want to create a user for that. can be something like that:
+```bash
+CREATE USER gitlab_approval WITH PASSWORD 'zoohoo6T';
+GRANT SELECT, UPDATE (merge_status,merge_error) ON TABLE merge_requests TO gitlab_approval;
+```
 
 ## Contributing
 

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -17,17 +17,19 @@ import (
 )
 
 type ApprovRule struct {
-	ProjectId int       `json:"project_id"  validate:"required,gt=0"`
-	Approvals []string  `json:"approvals"   validate:"required"`
-	MinApprov int       `json:"min_approv"  validate:"required,gt=0"`
+	ProjectId int       `json:"project_id"              validate:"gt=0,required"`
+	Approvals []string  `json:"approvals"               validate:"gt=0,required"`
+	MinApprov int       `json:"min_approv"              validate:"gt=0,required"`
+	WebHookToken string `json:"webhook_token,omitempty" validate:"omitempty,gt=0"`
 }
 
 type Config struct {
-	GitlabToken string       `json:"gitlab_token"   validate:"required,startswith=glpat-"`
-	GitlabURL   string       `json:"gitlab_url"     validate:"required,http_url"`
-	Projects    []ApprovRule `json:"projects"       validate:"required"`
-	PsqlConn    string       `json:"psql_conn_url"  validate:"required,startswith=postgres://"`
-	CorsOrigin  string       `json:"cors_origin"    validate:"required"`
+	GitlabToken string       `json:"gitlab_token"            validate:"required,startswith=glpat-"`
+	GitlabURL   string       `json:"gitlab_url"              validate:"required,http_url"`
+	Projects    []ApprovRule `json:"projects"                validate:"required"`
+	PsqlConn    string       `json:"psql_conn_url"           validate:"required,startswith=postgres://"`
+	CorsOrigin  string       `json:"cors_origin"             validate:"required"`
+	WebHookToken string      `json:"webhook_token,omitempty" validate:"omitempty,gt=0"`
 }
 
 // NewDefaultConfig reads configuration from environment variables and validates it

--- a/internal/conf/conf_test.go
+++ b/internal/conf/conf_test.go
@@ -24,8 +24,10 @@ func TestNewConfig(t *testing.T) {
 	validConfig := `{
 		"gitlab_token": "glpat-Phuki3Xu5Rohghohrode",
 		"gitlab_url": "https://gitlab.com",
+		"webhook_token": "ddalsdnHAS8OP",
 		"projects": [
 			{
+				"webhook_token": "aaKJHJhasa122AS",
 				"project_id": 1,
 				"approvals": ["user1", "user2"],
 				"min_approv": 2
@@ -47,10 +49,12 @@ func TestNewConfig(t *testing.T) {
 		assert.NotNil(t, conf, "Expected a non-nil config object")
 		assert.Equal(t, "glpat-Phuki3Xu5Rohghohrode", conf.GitlabToken, "Unexpected GitlabToken")
 		assert.Equal(t, "https://gitlab.com", conf.GitlabURL, "Unexpected GitlabURL")
+		assert.Equal(t, "ddalsdnHAS8OP", conf.WebHookToken, "Unexpected WebHookToken")
 		assert.Len(t, conf.Projects, 1, "Expected one project in the config")
 		assert.Equal(t, 1, conf.Projects[0].ProjectId, "Unexpected ProjectId")
 		assert.Equal(t, []string{"user1", "user2"}, conf.Projects[0].Approvals, "Unexpected Approvals")
 		assert.Equal(t, 2, conf.Projects[0].MinApprov, "Unexpected MinApprov")
+		assert.Equal(t, "aaKJHJhasa122AS", conf.Projects[0].WebHookToken, "Unexpected WebHookToken")
 		assert.Equal(t, "postgres://user:password@localhost/dbname", conf.PsqlConn, "Unexpected PsqlConn")
 		assert.Equal(t, "https://example.com", conf.CorsOrigin, "Unexpected CorsOrigin")
 	})


### PR DESCRIPTION
feat(README.md): add support for project-specific webhook_token in configuration to allow defining webhook tokens at project level
feat(README.md): update README with information about the webhook_token field in project configuration
feat(conf.go): add WebHookToken field to ApprovRule struct to support defining webhook tokens at project level
feat(conf.go): add WebHookToken field to Config struct to support defining a global webhook token
feat(conf_test.go): update test data to include webhook_token field in project configuration
feat(webservices.go): add logic to handle and validate X-Gitlab-Token header in PostApproval endpoint
feat(webservices.go): add support for using project-specific webhook token in PostApproval endpoint logic
feat(webservices.go): add support for using global webhook token if project-specific token is not defined in PostApproval endpoint logic